### PR TITLE
Send source to 'getPreviousElement' function

### DIFF
--- a/src/emulate-tab.ts
+++ b/src/emulate-tab.ts
@@ -79,7 +79,7 @@ function emulateTabFrom(source: HTMLElement = document.body) {
      * 
      * @returns true if switched elemenet and false if default action had been prevented
      */
-    toPreviousElement: () => emulateTabFromSourceToTarget(source, getPreviousElement(), shiftModifier),
+    toPreviousElement: () => emulateTabFromSourceToTarget(source, getPreviousElement(source), shiftModifier),
 
     /**
      * emulate tab to the element after the starting element (which is the active element by default)


### PR DESCRIPTION
This allows the `getPreviousElement` function to know where in the document you want to be tabbing from so that it can correctly find the previous index

Without doing this the `getPreviousElement` function will default to the `document.body` as it's lookup and won't actually tab from where you intend it to.